### PR TITLE
v0.11.0-update-deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ percent-encode = ["url"]
 [dependencies]
 time = "0.1"
 url = { version = "1.0", optional = true }
-ring = { version = "0.13.0", optional = true }
+ring = { version = "0.16.11", optional = true }
 base64 = { version = "0.9.0", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
~~~toml
[replace]
"cookie:0.11.0" = { git = 'https://github.com/tamakiii/cookie-rs.git', branch = "v0.11.0-update-deps" }
~~~

~~~sh
root@5ce7ef80e8c0:/app# cargo update
    Updating crates.io index
error: failed to select a version for `ring`.
    ... required by package `rustls v0.16.0`
    ... which is depended on by `mongodb v0.9.1`
    ... which is depended on by `hello-rust-rocket-mongo v0.1.0 (/app)`
versions that meet the requirements `^0.16.5` are: 0.16.11, 0.16.10, 0.16.9, 0.16.7, 0.16.6, 0.16.5

the package `ring` links to the native library `ring-asm`, but it conflicts with a previous package which links to `ring-asm` as well:
package `ring v0.13.5`
    ... which is depended on by `cookie v0.11.0`
    ... which is depended on by `rocket_http v0.4.2`
    ... which is depended on by `rocket v0.4.2`
    ... which is depended on by `hello-rust-rocket-mongo v0.1.0 (/app)`

failed to select a version for `ring` which could resolve this conflict
~~~